### PR TITLE
Adding new optional parameter auth_signin URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -X POST \
 --url "http://localhost:8001/services/fibery-api/plugins" \
 --data "name=kong-auth-request" \
 --data "config.auth_uri=http://auth.fibery.io/authorize" \
+--data "config.auth_signin=http://auth.fibery.io/signin" \
 --data "config.auth_response_headers_to_forward[]=x-authorization"
 --data "config.origin_request_headers_to_forward_to_auth[]=host"
 ```
@@ -33,6 +34,7 @@ curl -X POST \
 config parameter | description
 -----------------|--------------
 config.auth_uri  | Plugin make a HTTP GET request with Authorization header to this URL before proxying the original request
+config.auth_signin | (optional) If specified, redirects the user to this URL if the HTTP GET to config.auth_uri returns 401
 config.auth_response_headers_to_forward | If auth request was successful then plugin takes header names from auth_response_headers_to_forward collection, then finds them in auth response headers and adds them into origin request before proxying it to upstream.
 config.origin_request_headers_to_forward_to_auth | Origin request headers to pass to auth uri
 ## Author

--- a/src/access.lua
+++ b/src/access.lua
@@ -27,6 +27,12 @@ function _M.execute(conf)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
     end
 
+    if conf.auth_signin ~= "" and res.status == 401 then
+        return kong.response.exit(302, "", {
+            ["Location"] = conf.auth_signin .. "?rd=" .. ngx.escape_uri(kong.request.get_scheme() .. "://" .. kong.request.get_host() .. kong.request.get_path_with_query())
+        })
+    end
+
     if res.status > 299 then
         return kong.response.exit(res.status, res.body)
     end

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -4,6 +4,7 @@ return {
         timeout = { default = 10000, type = "number" },
         keepalive_timeout = { default = 60000, type = "number" },
         auth_uri = { required = true, type = "string" },
+        auth_signin = { default="", type = "string" },
         origin_request_headers_to_forward_to_auth = { type = "array", default = {} },
         auth_response_headers_to_forward = { type = "array", default = {} }
     }


### PR DESCRIPTION
Thanks a lot for this plugin! Definitely a missing piece on kong's open source ecosystem (after all, the [oauth2 plugin](https://docs.konghq.com/hub/kong-inc/oauth2/) won't work in DB-less mode).

The idea of this patch is to check if the HTTP GET to auth_uri returns 401, then the proxy redirects the user to the URL specified in auth_signin. This reproduces the same functionality of <https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/>, thus allowing the use of a single sign-on URL when applicable.

The patch is meant to be backwards-compatible, as the auth_signin parameters is optional.